### PR TITLE
Hotfix: Specify explicit dtype for BSpline index offsets

### DIFF
--- a/uf3/representation/bspline.py
+++ b/uf3/representation/bspline.py
@@ -792,7 +792,7 @@ def find_spline_indices(points: np.ndarray,
     # identify basis function "center" per point
     idx = np.searchsorted(knot_sequence, points, side='left') - 1 - 3
     # tile to identify four non-zero basis functions per point
-    offsets = np.zeros(len(points) * 4)
+    offsets = np.zeros(len(points) * 4, dtype=np.int64)
     for i in range(4):
         offsets[i::4] = i
     # offsets = np.tile([0, 1, 2, 3], len(points))


### PR DESCRIPTION
Closes #15 