### PR TITLE
Consistent naming for saving and loading methods

### DIFF
--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -204,7 +204,8 @@ class WeightedLinearModel(BasicLinearModel):
         return model
 
     @staticmethod
-    def from_file(filename):
+    def from_json(filename):
+        """Load model (coefficients and knots map) from json file."""
         dump = json_io.load_interaction_map(filename)
         return WeightedLinearModel.from_dict(dump)
 
@@ -515,8 +516,8 @@ class WeightedLinearModel(BasicLinearModel):
         else:
             return y_e, p_e, y_f, p_f
 
-    def save(self, filename: str):
-        """Save model (coefficients and knots map) to file."""
+    def to_json(self, filename: str):
+        """Save model (coefficients and knots map) to json file."""
         json_io.dump_interaction_map(self.as_dict(),
                                      filename=filename,
                                      write=True)

--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -563,12 +563,12 @@ class WeightedLinearModel(BasicLinearModel):
                     f"Incorrect shape: {pair}, {n_provided} != {n_target}"
                 )
         for trio in self.bspline_config.interactions_map.get(3, []):
-            n_target = len(component_len[trio])
+            n_target = component_len[trio]
             if trio not in solution:
                 warnings.warn(f"{trio} not provided.")
             if trio in solution:
                 # decompress if necessary
-                component = solution[trio]
+                component = np.array(solution[trio])
                 if len(np.shape(component)) > 1:
                     vector = self.bspline_config.compress_3B(component,
                                                              trio)


### PR DESCRIPTION
The current methods for saving and loading models are `save` and `from_file`.
Changing their names to `to_json` and `from_json` is more consistent and signals clearly, what is saved and in which format.