### PR TITLE
Correct element sorting method

### DIFF
--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -547,8 +547,8 @@ class WeightedLinearModel(BasicLinearModel):
             solution = solution["solution"]
         for key in solution:
             if isinstance(key, tuple):
-                sorted_key = composition.sort_elements(key)
-                if tuple(sorted_key) != key:
+                sorted_key = composition.sort_interaction_symbols(key)
+                if sorted_key != key:
                     solution[sorted_key] = solution[key]
         # consistency check with bspline_config
         component_len = self.bspline_config.get_interaction_partitions()[0]


### PR DESCRIPTION
# Issue description

The current element sorting method returns lists and sorts every element. This leads to runtime exceptions when loading models and incorrect three-body interactions. This issue is fixed by using the `sort_interaction_symbols` method that returns tuples and fixes central elements.