### PR TITLE
Update scikit-learn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 pandas
 plotly
 PyYAML
-sklearn
+scikit-learn
 scipy
 tables
 tqdm


### PR DESCRIPTION
It seems that the name of the scikit-learn package on PyPI changed, which prevented me from installing it straight away. I've simply updated it here.

After this everything went smoothly and I had a good afternoon playing with it, thanks for providing the detailed example notebooks!