### PR TITLE
Triangle bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 uf3.egg-info/dependency_links.txt
 
 uf3.egg-info/PKG-INFO
@@ -56,3 +55,11 @@ uf3/util/__pycache__/plotting.cpython-37.pyc
 uf3/util/__pycache__/subsample.cpython-37.pyc
 
 lammps_plugin/ML-UF3/.vscode/
+
+.vscode/
+
+*/__pycache__
+
+*/*/__pycache__
+
+*/*/*/__pycache__

--- a/uf3/data/composition.py
+++ b/uf3/data/composition.py
@@ -53,7 +53,7 @@ class ChemicalSystem:
                 e.g. 2 to fit pair potentials.
         """
         self.degree = degree
-        self.element_list = sort_interaction_symbols(element_list)
+        self.element_list = sort_interaction_symbols(list(set(element_list)), fix_first=False)
         self.numbers = [ase_symbols.symbols2numbers(el).pop()
                         for el in self.element_list]
         self.interactions_map = self.get_interactions_map()
@@ -130,6 +130,7 @@ class ChemicalSystem:
                                      key=lambda c: [reference_X[x] for x in c])
         for d in range(3, self.degree + 1):
             combinations = get_element_combinations(self.element_list, d)
+            combinations.sort(key=lambda c: [reference_X[x] for x in c])
             interactions_map[d] = combinations
         return interactions_map
 
@@ -190,12 +191,12 @@ def sort_interaction_map(imap: Dict[Tuple[str], Any]) -> Dict[Tuple[str], Any]:
     return {sort_interaction_symbols(k): v for k, v in imap.items()}
 
 
-def sort_interaction_symbols(symbols: Collection[str]) -> Tuple:
+def sort_interaction_symbols(symbols: Collection[str], fix_first=True) -> Tuple:
     """
     Sort interaction tuple by electronegativities.
     For consistency, many-body interactions (i.e. >2) are sorted while fixing
     the first (center) element."""
-    if len(symbols) >= 3:
+    if len(symbols) >= 3 and fix_first:
         center = symbols[0]
         symbols = sort_elements(symbols[1:])
         symbols.insert(0, center)

--- a/uf3/default_options.yaml
+++ b/uf3/default_options.yaml
@@ -48,5 +48,7 @@ learning:
     weight: 0.5
     regularizer:
         ridge_1b: 1.0e-8
+        ridge_2b: 0.0
+        ridge_3b: 1e-5
         curvature_2b: 1.0e-8
         curvature_3b: 1.0e-8

--- a/uf3/forcefield/calculator.py
+++ b/uf3/forcefield/calculator.py
@@ -13,6 +13,7 @@ import ase
 from ase import optimize as ase_optim
 from ase import constraints as ase_constraints
 from ase.calculators import calculator as ase_calc
+from ase import data as ase_data
 
 from uf3.data import geometry
 from uf3.representation import distances
@@ -174,8 +175,10 @@ class UFCalculator(ase_calc.Calculator):
         energy = 0.0
 
         trio_list = self.bspline_config.interactions_map[3]
+        trio_numbers_list = [tuple(ase_data.atomic_numbers[elem] for elem in trio) for trio in trio_list]
         hashes = self.bspline_config.chemical_system.interaction_hashes[3]
-        n_interactions = len(hashes)
+        hash2interaction = {hash: interaction for hash, interaction in zip(hashes, trio_numbers_list)}
+        n_interactions = len(hash2interaction)
         knot_sets = [self.bspline_config.knots_map[trio] for trio in trio_list]
 
         sup_comp = supercell.get_atomic_numbers()
@@ -184,7 +187,7 @@ class UFCalculator(ase_calc.Calculator):
                                                            knot_sets,
                                                            supercell)
         triplet_generator = angles.generate_triplets(
-            i_where, j_where, sup_comp, hashes, dist_matrix, knot_sets)
+            i_where, j_where, sup_comp, hash2interaction, dist_matrix, knot_sets)
 
         for triplet_batch in triplet_generator:
             for interaction_idx in range(n_interactions):
@@ -249,8 +252,10 @@ class UFCalculator(ase_calc.Calculator):
         forces = np.zeros((n_atoms, 3))
 
         trio_list = self.bspline_config.interactions_map[3]
+        trio_numbers_list = [tuple(ase_data.atomic_numbers[elem] for elem in trio) for trio in trio_list]
         hashes = self.bspline_config.chemical_system.interaction_hashes[3]
-        n_interactions = len(hashes)
+        hash2interaction = {hash: interaction for hash, interaction in zip(hashes, trio_numbers_list)}
+        n_interactions = len(hash2interaction)
         knot_sets = [self.bspline_config.knots_map[trio] for trio in trio_list]
 
         sup_comp = supercell.get_atomic_numbers()
@@ -260,7 +265,7 @@ class UFCalculator(ase_calc.Calculator):
                                                               supercell,
                                                               square=True)
         triplet_generator = angles.generate_triplets(
-            x_where, y_where, sup_comp, hashes, matrix, knot_sets)
+            x_where, y_where, sup_comp, hash2interaction, matrix, knot_sets)
 
         for triplet_batch in triplet_generator:
             for interaction_idx in range(n_interactions):

--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -300,12 +300,14 @@ class WeightedLinearModel(BasicLinearModel):
                                   self.col_idx)
         gram_e, ord_e = batched_moore_penrose(x_e, y_e, batch_size=batch_size)
         if x_f is not None:
+            warnings.filterwarnings("error", append=True)  # to catch divide by zero warnings
             try:
                 energy_weight = 1 / len(y_e) / np.std(y_e)
                 force_weight = 1 / len(y_f) / np.std(y_f)
-            except (ZeroDivisionError, FloatingPointError):
+            except (ZeroDivisionError, FloatingPointError, RuntimeWarning):
                 energy_weight = 1.0
                 force_weight = 1 / len(y_f)
+            warnings.filters.pop()  # undo the filter
             x_f, y_f = freeze_columns(x_f,
                                       y_f,
                                       self.mask,
@@ -403,8 +405,14 @@ class WeightedLinearModel(BasicLinearModel):
             gram_f += g_f
             ord_e += o_e
             ord_f += o_f
-        energy_weight = 1 / e_variance.n / e_variance.std
-        force_weight = 1 / f_variance.n / f_variance.std
+        warnings.filterwarnings("error", append=True)  # to catch divide by zero warnings
+        try:
+            energy_weight = 1 / e_variance.n / e_variance.std
+            force_weight = 1 / f_variance.n / f_variance.std
+        except (ZeroDivisionError, FloatingPointError, RuntimeWarning):
+            energy_weight = 1.0
+            force_weight = 1 / f_variance.n
+        warnings.filters.pop()  # undo the filter
         gram, ordinate = self.combine_weighted_gram(gram_e,
                                                     gram_f,
                                                     ord_e,
@@ -489,9 +497,9 @@ class WeightedLinearModel(BasicLinearModel):
 
         Returns:
             y_e (np.ndarray): target values for energies.
-            p_e (np.ndarray): prediction values for forces.
-            y_f (np.ndarray): target values for energies.
-            p_f (np.ndarray): target values for forces.
+            p_e (np.ndarray): prediction values for energies.
+            y_f (np.ndarray): target values for forces.
+            p_f (np.ndarray): prediction values for forces.
             rmse_e (np.ndarray): RMSE across energy predictions.
             rmse_e (np.ndarray): RMSE across force predictions.
         """
@@ -669,9 +677,6 @@ def dataframe_to_tuples(df_features,
         y (np.ndarray): target vector.
         w (np.ndarray): weight vector for machine learning.
     """
-    if len(df_features) <= 1:
-        raise ValueError(
-            "Not enough samples ({} provided)".format(len(df_features)))
     names = df_features.index.get_level_values(0)
     y_index = df_features.index.get_level_values(-1)
     energy_mask = (y_index == energy_key)
@@ -934,9 +939,9 @@ def subset_prediction(df: pd.DataFrame,
 
     Returns:
         y_e (np.ndarray): target values for energies.
-        p_e (np.ndarray): prediction values for forces.
-        y_f (np.ndarray): target values for energies.
-        p_f (np.ndarray): target values for forces.
+        p_e (np.ndarray): prediction values for energies.
+        y_f (np.ndarray): target values for forces.
+        p_f (np.ndarray): prediction values for forces.
     """
     if subset_keys is not None:
         idx = df.index.unique(level=0).intersection(subset_keys)
@@ -967,9 +972,9 @@ def batched_prediction(model: WeightedLinearModel,
 
     Returns:
         y_e (np.ndarray): target values for energies.
-        p_e (np.ndarray): prediction values for forces.
-        y_f (np.ndarray): target values for energies.
-        p_f (np.ndarray): target values for forces.
+        p_e (np.ndarray): prediction values for energies.
+        y_f (np.ndarray): target values for forces.
+        p_f (np.ndarray): prediction values for forces.
     """
     if table_names is None:
         _, _, table_names, _ = io.analyze_hdf_tables(filename)

--- a/uf3/representation/bspline.py
+++ b/uf3/representation/bspline.py
@@ -176,7 +176,8 @@ class BSplineBasis:
             if isinstance(r_max, (float, np.floating, int)):
                 values.append(r_max)
             else:
-                values.append(r_max[0])
+                # higher body interactions: get max r involving central atom
+                values.append( max(r_max[:len(interaction)-1]) )
         return max(values)
 
     def update_knots(self,
@@ -234,16 +235,38 @@ class BSplineBasis:
             self.r_max_map[trio] = self.r_max_map.get(trio, default_max)
             self.resolution_map[trio] = self.resolution_map.get(trio,
                                                                 default_res)
-            min_set = len(set(self.r_min_map[trio]))
-            max_set = len(set(self.r_max_map[trio]))
-            res_set = len(set(self.resolution_map[trio]))
-            if min_set == 1 and max_set == 1 and res_set == 1:
-                self.symmetry[trio] = 3
-            elif min_set <= 2 and max_set <= 2 and res_set <= 2:
-                self.symmetry[trio] = 2
-            else:
-                self.symmetry[trio] = 1
+            self.find_symmetry_3B(trio)
         self.r_cut = self.get_cutoff()
+
+
+    def find_symmetry_3B(self, trio):
+        """
+        Sets self.symmetry[trio] based on r_min, r_max, and resolution map
+
+        Args:
+            trio (tuple): tuple containing 3 elements
+        Updates:
+            self.symmetry[trio]
+        Returns:
+            None
+        """
+        elem_set = len(set(trio[1:]))
+
+        # 2 neighboring elements are different
+        if elem_set == 2:
+            self.symmetry[trio] = 1
+            return None
+        
+        # 2 neighboring elements are identical
+        configs = set(zip(
+            self.r_min_map[trio],
+            self.r_max_map[trio],
+            self.resolution_map[trio]
+        ))
+
+        # 1->3, 2->2, 3->1
+        self.symmetry[trio] = -1 * (len(configs) - 2) + 2
+
 
     def update_knots_from_dict(self, knots_map):
         """"""
@@ -358,9 +381,9 @@ class BSplineBasis:
 
         Args:
             ridge_map (dict): n-body term ridge regularizer strengths.
-                default: {1: 1e-4, 2: 1e-6, 3: 1e-5}
+                default: {1: 1e-8, 2: 0e0, 3: 1e-5}
             curvature_map (dict): n-body term curvature regularizer strengths.
-                default: {1: 0.0, 2: 1e-5, 3: 1e-5}
+                default: {1: 0.0, 2: 1e-8, 3: 1e-8}
 
         TODO: refactor to break up into smaller, reusable functions
 
@@ -560,11 +583,11 @@ class BSplineBasis:
 
         """
         if self.symmetry[interaction] == 1:
-            vec = grid.flatten()
+            vec = grid
+            redundancy = self.flat_weights[interaction] if fitting else 1.0
         elif self.symmetry[interaction] == 2:
             vec = grid + grid.transpose(1, 0, 2)
-            vec = vec.flat[self.template_mask[interaction]]
-            vec = vec * (self.flat_weights[interaction] if fitting else 0.5)
+            redundancy = self.flat_weights[interaction] if fitting else 0.5
         elif self.symmetry[interaction] == 3:
             vec = (grid
                    + grid.transpose(0, 2, 1)
@@ -572,8 +595,9 @@ class BSplineBasis:
                    + grid.transpose(1, 2, 0)
                    + grid.transpose(2, 0, 1)
                    + grid.transpose(2, 1, 0))
-            vec = vec.flat[self.template_mask[interaction]]
-            vec = vec * self.flat_weights[interaction]
+            redundancy = self.flat_weights[interaction] if fitting else 1/6
+        vec = vec.flat[self.template_mask[interaction]]
+        vec = vec * redundancy
         return vec
 
     def decompress_3B(self, vec, interaction):
@@ -593,7 +617,15 @@ class BSplineBasis:
         N = len(n_space) - 4
         grid = np.zeros((L, M, N))
         grid.flat[self.template_mask[interaction]] = vec
-        grid = grid + grid.transpose(1, 0, 2)
+        if self.symmetry[interaction] == 2:
+            grid = grid + grid.transpose(1, 0, 2)
+        elif self.symmetry[interaction] == 3:
+            grid = (grid
+                    + grid.transpose(0, 2, 1)
+                    + grid.transpose(1, 0, 2)
+                    + grid.transpose(1, 2, 0)
+                    + grid.transpose(2, 0, 1)
+                    + grid.transpose(2, 1, 0))
         return grid
 
 

--- a/uf3/representation/process.py
+++ b/uf3/representation/process.py
@@ -527,6 +527,7 @@ class BasisFeaturizer:
             y (np.ndarray): target vector.
             w (np.ndarray): weight vector for machine learning.
         """
+        warnings.warn("get_training_tuples() is deprecated.", DeprecationWarning)
         energy_key = data_coordinator.energy_key
         x, y, w = dataframe_to_training_tuples(df_features,
                                                kappa=kappa,

--- a/uf3/representation/process.py
+++ b/uf3/representation/process.py
@@ -9,6 +9,7 @@ import warnings
 import sqlite3
 import numpy as np
 import pandas as pd
+import ase.data as ase_data
 from uf3.representation import distances
 from uf3.representation import angles
 from uf3.representation import bspline
@@ -308,7 +309,7 @@ class BasisFeaturizer:
                 {(name, 'e'), (name, 'fx'), ...{ instead of {'e', 'fx', ...}
             energy (float): energy of configuration (optional).
             forces (list, np.ndarray): array containing force components
-                fx, fy, fz for each atom. Expected shape is (n_atoms, 3).
+                fx, fy, fz for each atom. Expected shape is (3, natoms).
             energy_key (str): column name for energies, default "energy".
 
         Returns:
@@ -452,13 +453,14 @@ class BasisFeaturizer:
         if supercell is None:
             supercell = geom
         trio_list = self.interactions_map[3]
+        trio_numbers_list = [tuple(ase_data.atomic_numbers[elem] for elem in trio) for trio in trio_list]
         knot_sets = [self.knots_map[trio] for trio in trio_list]
         basis_functions = [self.basis_functions[trio] for trio in trio_list]
-        hashes = self.interaction_hashes[3]
+        hash2interaction = {hash: interaction for hash, interaction in zip(self.interaction_hashes[3], trio_numbers_list)}
         grids = angles.featurize_energy_3b(geom,
                                            knot_sets,
                                            basis_functions,
-                                           hashes,
+                                           hash2interaction,
                                            supercell=supercell,
                                            n_lead=self.leading_trim,
                                            n_trail=self.trailing_trim)
@@ -486,13 +488,14 @@ class BasisFeaturizer:
         if supercell is None:
             supercell = geom
         trio_list = self.interactions_map[3]
+        trio_numbers_list = [tuple(ase_data.atomic_numbers[elem] for elem in trio) for trio in trio_list]
         knot_sets = [self.knots_map[trio] for trio in trio_list]
         basis_functions = [self.basis_functions[trio] for trio in trio_list]
-        hashes = self.interaction_hashes[3]
+        hash2interaction = {hash: interaction for hash, interaction in zip(self.interaction_hashes[3], trio_numbers_list)}
         grids = angles.featurize_force_3b(geom,
                                           knot_sets,
                                           basis_functions,
-                                          hashes,
+                                          hash2interaction,
                                           supercell=supercell,
                                           n_lead=self.leading_trim,
                                           n_trail=self.trailing_trim)


### PR DESCRIPTION
Fixes to the generate_triplets bug during featurizing 3B and the ij symmetry bug during 3B tensor compression. Both cases now look at identities of the neighbor atoms.

Files with bugfixes are:

- uf3/forcefield/calculator.py
- uf3/representation/angles.py
- uf3/representation/bspline.py
- uf3/representation/process.py

Other modified files with noncritical (but definitely beneficial) edits are:

- .gitignore
- uf3/data/composition.py
- uf3/default_options.yaml
- uf3/regression/least_squares.py 