### PR TITLE
symmetry bug fix

### DIFF
--- a/tests/test_bsplines.py
+++ b/tests/test_bsplines.py
@@ -29,12 +29,6 @@ def binary_unsym_trio():
     return ('Si','Si','N') 
 
 @pytest.fixture
-def SungTest():
-    return dict(r_min = [0.1,0.1,0.2],
-                r_max = [5.,10.,5.],
-                resolution = [10,20,20])
-
-@pytest.fixture
 def equilateral():
     return dict(r_min = [0.1,0.1,0.1],
                 r_max = [8.,8.,8.],
@@ -114,16 +108,13 @@ def isosceles_rmax_resolution_scalene_rmin():
                 r_max = [5.,5.,10.],
                 resolution = [6,6,12])
 
+@pytest.fixture
+def scalene_all_diff():
+    return dict(r_min = [0.1,0.1,0.2],
+                r_max = [5.,10.,5.],
+                resolution = [10,20,20])
+
 class TestFindSym3Body:
-    def test_SungTest_unary(self,unary_trio,SungTest):
-        assert find_symmetry_3B(unary_trio,**SungTest) == 1
-
-    def test_SungTest_binary_sym(self,binary_sym_trio,SungTest):
-        assert find_symmetry_3B(binary_sym_trio,**SungTest) == 1
-
-    def test_SungTest_binary_unsym(self,binary_unsym_trio,SungTest):
-        assert find_symmetry_3B(binary_unsym_trio,**SungTest) == 1
-
     def test_equilateral_unary(self,unary_trio,equilateral):
         assert find_symmetry_3B(unary_trio,**equilateral) == 3
         
@@ -243,7 +234,16 @@ class TestFindSym3Body:
 
     def test_binary_sym_isosceles_rmax_resolution_scalene_rmin(self,binary_sym_trio,isosceles_rmax_resolution_scalene_rmin):
         assert find_symmetry_3B(binary_sym_trio,**isosceles_rmax_resolution_scalene_rmin) == 1
-        
+
+    def test_scalene_unary_all_diff(self,unary_trio,scalene_all_diff):
+        assert find_symmetry_3B(unary_trio,**scalene_all_diff) == 1
+
+    def test_scalene_binary_sym_all_diff(self,binary_sym_trio,scalene_all_diff):
+        assert find_symmetry_3B(binary_sym_trio,**scalene_all_diff) == 1
+
+    def test_scalene_binary_unsym_all_diff(self,binary_unsym_trio,scalene_all_diff):
+        assert find_symmetry_3B(binary_unsym_trio,**scalene_all_diff) == 1
+       
 class TestKnots:
     def test_knot_sequence_from_points(self):
         sequence = knot_sequence_from_points([1, 2, 3])

--- a/tests/test_bsplines.py
+++ b/tests/test_bsplines.py
@@ -29,7 +29,13 @@ def binary_unsym_trio():
     return ('Si','Si','N') 
 
 @pytest.fixture
-def equalateral():
+def SungTest():
+    return dict(r_min = [0.1,0.1,0.2],
+                r_max = [5.,10.,5.],
+                resolution = [10,20,20])
+
+@pytest.fixture
+def equilateral():
     return dict(r_min = [0.1,0.1,0.1],
                 r_max = [8.,8.,8.],
                 resolution = [10,10,10])
@@ -109,14 +115,23 @@ def isosceles_rmax_resolution_scalene_rmin():
                 resolution = [6,6,12])
 
 class TestFindSym3Body:
-    def test_equilateral_unary(self,unary_trio,equalateral):
-        assert find_symmetry_3B(unary_trio,**equalateral) == 3
+    def test_SungTest_unary(self,unary_trio,SungTest):
+        assert find_symmetry_3B(unary_trio,**SungTest) == 1
+
+    def test_SungTest_binary_sym(self,binary_sym_trio,SungTest):
+        assert find_symmetry_3B(binary_sym_trio,**SungTest) == 1
+
+    def test_SungTest_binary_unsym(self,binary_unsym_trio,SungTest):
+        assert find_symmetry_3B(binary_unsym_trio,**SungTest) == 1
+
+    def test_equilateral_unary(self,unary_trio,equilateral):
+        assert find_symmetry_3B(unary_trio,**equilateral) == 3
         
-    def test_equilateral_binary_sym(self,binary_sym_trio,equalateral):   
-        assert find_symmetry_3B(binary_sym_trio,**equalateral) == 2 
+    def test_equilateral_binary_sym(self,binary_sym_trio,equilateral):   
+        assert find_symmetry_3B(binary_sym_trio,**equilateral) == 2 
         
-    def test_equilateral_binary_unsym(self,binary_unsym_trio,equalateral):
-        assert find_symmetry_3B(binary_unsym_trio,**equalateral) == 1        
+    def test_equilateral_binary_unsym(self,binary_unsym_trio,equilateral):
+        assert find_symmetry_3B(binary_unsym_trio,**equilateral) == 1        
         
     def test_isosceles_unary_rmax_rjk(self,unary_trio,isosceles_rmax_rjk):
         assert find_symmetry_3B(unary_trio,**isosceles_rmax_rjk) == 2

--- a/uf3/representation/bspline.py
+++ b/uf3/representation/bspline.py
@@ -611,6 +611,8 @@ def find_symmetry_3B(trio: Tuple,
                      resolution: List):
 
     """
+    Calculates the symmetry of a 3-body interaction based on r_min, r_max, and
+    resolution map.
 
     Args:
         trio (tuple): Interaction (Si,Si,N)


### PR DESCRIPTION
Fixed bug related to the symmetry of 3-body interactions.

The determination of the `self.symmetry` variable was moved out of `update_knots()` and as its own method called `find_symmetry_3B()`. It now looks at the identities of the 2 neighbor atoms to determine the symmetry, in addition to the knot settings.

The 3-body coefficient tensor compression and decompression algorithms were also slightly modified. Previously, all compression and decompression of 3-body terms were done assuming that it had 2-way symmetry. However, now it can handle 1-way and 3-way symmetries too.