### PR TITLE
generate_triplets bug fix

### DIFF
--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -47,6 +47,7 @@ def binary_chemistry():
     yield chemistry_config
 @pytest.fixture()
 def atom1():
+    x = 1
     yield None
     
 class TestBasis:

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -45,8 +45,10 @@ def binary_chemistry():
     element_list = ['Ne', 'Xe']
     chemistry_config = composition.ChemicalSystem(element_list)
     yield chemistry_config
-
-
+@pytest.fixture()
+def atom1():
+    yield None
+    
 class TestBasis:
     def test_setup(self, unary_chemistry):
         bspline_config = bspline.BSplineBasis(unary_chemistry)

--- a/uf3/representation/angles.py
+++ b/uf3/representation/angles.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Tuple
 import numpy as np
 from numba import jit
 import ase
-from ase.data import chemical_symbols as ase_symbols
+from ase import symbols as ase_symbols
 from uf3.data import composition
 from uf3.representation import bspline
 from uf3.representation import distances

--- a/uf3/representation/angles.py
+++ b/uf3/representation/angles.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Tuple
 import numpy as np
 from numba import jit
 import ase
+from ase.data import chemical_symbols as ase_symbols
 from uf3.data import composition
 from uf3.representation import bspline
 from uf3.representation import distances
@@ -391,7 +392,7 @@ def generate_triplets(i_where: np.ndarray,
                       knot_sets: List[List[np.ndarray]]
                       ) -> List[Tuple]:
     """
-    Identify unique "i-j-j'" tuples by combining provided i-j pairs, then
+    Identify unique "i-j-k" tuples by combining provided i-j pairs, then
     compute i-j, i-k, and j-k pair distances from i-j-k tuples,
         distance matrix, and knot sequence for cutoffs.
 
@@ -418,21 +419,55 @@ def generate_triplets(i_where: np.ndarray,
         tuples = np.array(np.meshgrid(i_groups[i],
                                       i_groups[i])).T.reshape(-1, 2)
         tuples = np.insert(tuples, 0, i_values[i], axis=1)
-
         comp_tuples = sup_composition[tuples]
-        comp_tuples[:, 1:] = np.sort(comp_tuples[:, 1:], axis=1)
-
+        
+        sort_indices = np.argsort(comp_tuples[:, 1:],axis=1)
+        comp_tuples_slice = np.take_along_axis(comp_tuples[:, 1:],sort_indices,axis=1)
+        tuples_slice = np.take_along_axis(tuples[:, 1:],sort_indices,axis=1)
+        
+        comp_tuples = np.hstack((comp_tuples[:, [0]], comp_tuples_slice))
+        tuples = np.hstack((tuples[:, [0]], tuples_slice))
+        
         ijk_hash = composition.get_szudzik_hash(comp_tuples)
 
         grouped_triplets = [None] * n_hashes
         for j, hash_ in enumerate(hashes):
             ituples = tuples[ijk_hash == hash_]
+            icomp_tuples = comp_tuples[ijk_hash == hash_]
             if len(ituples) == 0:
                 grouped_triplets[j] = None
                 continue
-            # atoms j and k are interchangable; filter
-            comparison_mask = (ituples[:, 1] < ituples[:, 2])
-            ituples = ituples[comparison_mask]
+            
+            # Check if same neighbouring elements
+            if icomp_tuples[0][1] == icomp_tuples[0][2]:
+                # element at j and k are same;
+                # remove redundant interactions
+                comparison_mask = (ituples[:, 1] < ituples[:, 2])
+                ituples = ituples[comparison_mask]
+                icomp_tuples = icomp_tuples[comparison_mask]
+
+            else:
+                # Elements at j and k not same
+                # cordinates of j and k are same; filter eg 011, 022, 033
+                # this comparison mask is redundant
+                comparison_mask = (ituples[:, 1] != ituples[:, 2])
+
+                ituples = ituples[comparison_mask]
+                icomp_tuples = icomp_tuples[comparison_mask]
+                
+                if len(ituples) > 0:
+                    # Remove repetitive interactions
+                    ituples = np.unique(ituples,axis=0)
+                    icomp_tuples = np.unique(icomp_tuples,axis=0)
+                    
+                    # sort by electro-negativity as the interaction tuple is always
+                    # sorted by electro-negativity
+                    en_j = composition.reference_X[ase_symbols.chemical_symbols[icomp_tuples[0][1]]]
+                    en_k = composition.reference_X[ase_symbols.chemical_symbols[icomp_tuples[0][2]]]
+                    if  en_k < en_j:
+                        # Interchange columns 1 and 2
+                        ituples[:, [1, 2]] = ituples[:, [2, 1]]
+
             # extract distance tuples
             r_l = distance_matrix[ituples[:, 0], ituples[:, 1]]
             r_m = distance_matrix[ituples[:, 0], ituples[:, 2]]
@@ -449,7 +484,11 @@ def generate_triplets(i_where: np.ndarray,
             r_m = r_m[dist_mask]
             r_n = r_n[dist_mask]
             ituples = ituples[dist_mask]
-            grouped_triplets[j] = i, r_l, r_m, r_n, ituples
+            
+            if len(ituples) == 0:
+                grouped_triplets[j] = None
+            else:
+                grouped_triplets[j] = i, r_l, r_m, r_n, ituples
         yield grouped_triplets
 
 


### PR DESCRIPTION
The main fix is in `uf3.representation.angles.py: generate_triplets()`. All other changes are just to accommodate for the change in the arguments of `generate_triplets()`.

The fix starts in line 437 of `angles.py`, where the distance triplets in the `ituples` is ordered by the corresponding element order given by `interaction_tuple`.

I tried to change things as little as possible, but this fact made it hard to find a minimal change:

- the interaction tuples are written in terms of **atomic symbols** and ordered by **electronegativity** (given in `uf3.data.composition.py`)
- the hashing must be done with **atomic numbers** ordered by **atomic number**

If the core developers are open to big changes that restructure how the interaction tuples are made and whether hashes should be/not be used, I am also open to the change.