### PR TITLE
Predictable element and interaction tuple ordering (part 1)

### DIFF
--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -23,6 +23,34 @@ class TestChemistryConfig:
         assert len(handler.interactions_map[2]) == 6
         assert handler.numbers == [13, 29, 40]
 
+    def test_quaternary(self):
+        element_list = ['He', 'Li', 'H', 'Be']  # out of order on purpose
+        handler = ChemicalSystem(element_list, degree=3)
+        assert handler.interactions_map[2] == [
+            ('H', 'H'), ('H', 'He'),  ('H', 'Li'),  ('H', 'Be' ),
+                        ('He', 'He'), ('He', 'Li'), ('He', 'Be'),
+                                      ('Li', 'Li'), ('Li', 'Be'),
+                                                    ('Be', 'Be')
+                                                    ]  # in this order
+        assert handler.interactions_map[3] == [
+            ('H', 'H', 'H'  ), ('H', 'H', 'He'), ('H', 'H', 'Li'), ('H', 'H', 'Be'),
+            ('H', 'He', 'He'), ('H', 'He', 'Li'), ('H', 'He', 'Be'),
+            ('H', 'Li', 'Li'), ('H', 'Li', 'Be'),
+            ('H', 'Be', 'Be'),
+            ('He', 'H', 'H' ), ('He', 'H', 'He'), ('He', 'H', 'Li'), ('He', 'H', 'Be'),
+            ('He', 'He', 'He'), ('He', 'He', 'Li'), ('He', 'He', 'Be'),
+            ('He', 'Li', 'Li'), ('He', 'Li', 'Be'),
+            ('He', 'Be', 'Be'),
+            ('Li', 'H', 'H' ), ('Li', 'H', 'He'), ('Li', 'H', 'Li'), ('Li', 'H', 'Be'),
+            ('Li', 'He', 'He'), ('Li', 'He', 'Li'), ('Li', 'He', 'Be'),
+            ('Li', 'Li', 'Li'), ('Li', 'Li', 'Be'),
+            ('Li', 'Be', 'Be'),
+            ('Be', 'H', 'H' ), ('Be', 'H', 'He'), ('Be', 'H', 'Li'), ('Be', 'H', 'Be'),
+            ('Be', 'He', 'He'), ('Be', 'He', 'Li'), ('Be', 'He', 'Be'),
+            ('Be', 'Li', 'Li'), ('Be', 'Li', 'Be'),
+            ('Be', 'Be', 'Be')
+        ]  # in this order
+
     def test_composition_tuple(self):
         element_list = ['Al', 'Cu', 'Zr']
         handler = ChemicalSystem(element_list)

--- a/uf3/data/composition.py
+++ b/uf3/data/composition.py
@@ -126,6 +126,7 @@ class ChemicalSystem:
                                      key=lambda c: [reference_X[x] for x in c])
         for d in range(3, self.degree + 1):
             combinations = get_element_combinations(self.element_list, d)
+            combinations.sort(key=lambda c: [reference_X[x] for x in c])
             interactions_map[d] = combinations
         return interactions_map
 


### PR DESCRIPTION
It would be useful if the 3-body interaction tuples were ordered logically and predictably. For instance, if I create a `BSplineBasis` object using the element list `['He', 'Li', 'H']` (exactly in this order), the 3-body interaction tuples I get are:

    [('H', 'H', 'H'), ('H', 'Li', 'Li'), ('H', 'H', 'Li'), ('H', 'He', 'He'), ('H', 'H', 'He'),
    ('H', 'He', 'Li'), ('He', 'Li', 'Li'), ('He', 'H', 'Li'), ('He', 'He', 'Li'), ('He', 'He', 'He'),
    ('He', 'H', 'H'), ('He', 'H', 'He'), ('Li', 'H', 'Li'), ('Li', 'H', 'He'), ('Li', 'H', 'H'),
    ('Li', 'He', 'Li'), ('Li', 'He', 'He'), ('Li', 'Li', 'Li')]

As seen above, the resulting tuples are not ordered in terms of atomic number.

For 2-body interaction tuples, the solution to this ordering is already written:

    interactions_map[2] = sorted(cwr, key=lambda c: [reference_X[x] for x in c])

My suggestion is to do exactly the same thing for higher-body interaction tuples. After this one-line fix, the new 3-body interaction tuples are:

    [('H', 'H', 'H'), ('H', 'H', 'He'), ('H', 'H', 'Li'), ('H', 'He', 'He'), ('H', 'He', 'Li'),
    ('H', 'Li', 'Li'), ('He', 'H', 'H'), ('He', 'H', 'He'), ('He', 'H', 'Li'), ('He', 'He', 'He'),
    ('He', 'He', 'Li'), ('He', 'Li', 'Li'), ('Li', 'H', 'H'), ('Li', 'H', 'He'), ('Li', 'H', 'Li'),
    ('Li', 'He', 'He'), ('Li', 'He', 'Li'), ('Li', 'Li', 'Li')]

Now, they are ordered predictably (`[1, 1, 1], [1, 1, 2], [1, 1, 3], [1, 2, 2], [1, 2, 3], ...`).