### PR TITLE
Minor documentation fix

### DIFF
--- a/uf3/representation/process.py
+++ b/uf3/representation/process.py
@@ -308,7 +308,7 @@ class BasisFeaturizer:
                 {(name, 'e'), (name, 'fx'), ...{ instead of {'e', 'fx', ...}
             energy (float): energy of configuration (optional).
             forces (list, np.ndarray): array containing force components
-                fx, fy, fz for each atom. Expected shape is (n_atoms, 3).
+                fx, fy, fz for each atom. Expected shape is (3, n_atoms).
             energy_key (str): column name for energies, default "energy".
 
         Returns:


### PR DESCRIPTION
This is a small correction to a method description mistake that I observed. The `forces` argument has shape `(3, n_atoms)`. This can be verified within the code because it is accessed like `forces[j][i]`, where 'j' is an element in `[0, 1, 2]`, and 'i' is an element in `range(n_atoms)`.