### PR TITLE
BSplineBasis r_cut fix

### DIFF
--- a/tests/test_bsplines.py
+++ b/tests/test_bsplines.py
@@ -387,3 +387,13 @@ def test_force_bspline():
     assert np.any(np.ptp(x, axis=0) > 0)  # but should not be entirely zero
     assert np.ptp(np.sum(x, axis=2)) < 1e-10  # values cancel across b-splines
     assert np.any(np.ptp(x, axis=2) > 0)  # but should not be entirely zero
+
+
+def test_bsplinebasis_r_cut():
+    element_list = ['Au']
+    chemistry = composition.ChemicalSystem(element_list, degree=3)
+    r_max_map = {('Au', 'Au'): 5.0,
+                 ('Au', 'Au', 'Au'): [5.1, 5.2, 10.3]}
+    bspline_handler = BSplineBasis(chemistry,
+                                   r_max_map=r_max_map)
+    assert bspline_handler.r_cut == 5.2

--- a/uf3/representation/bspline.py
+++ b/uf3/representation/bspline.py
@@ -176,7 +176,8 @@ class BSplineBasis:
             if isinstance(r_max, (float, np.floating, int)):
                 values.append(r_max)
             else:
-                values.append(r_max[0])
+                # higher body interactions: get max r involving central atom
+                values.append( max(r_max[:len(interaction)-1]) )
         return max(values)
 
     def update_knots(self,


### PR DESCRIPTION
The `r_cut` attribute of the `BSplineBasis` class in `uf3/representation/bspline.py` is used in `uf3/representation/distance.py` and `uf3/representation/process.py` during the featurization process to construct supercells and distance matrices.

So, the `r_cut` should be the largest `r_max` value that involves the central atom. Previously, it was just taking the 1st distance in the `r_max_map` for a given 3-body interaction.

In this solution, it is taking `max(r_max[:len(interaction)-1])`. This is to generalize to higher-body interactions, in case they will be added in the future.

For an n-body interaction, the length of the interaction tuple is `n`. Its relevant maps (e.g. `r_min_map`, `r_max_map`, `resolution_map`) will be of length `C(n, 2)`, where `C()` is the combinatorial function. Of these `C(n, 2)` numbers, the first `n-1` will involve the central atom. Hence, the indexing `len(interaction)-1` was used in the solution to select the relevant `r_max` values to consider in the `r_cut` calculation.

For example, for the 4-body interaction `(a, b, c, d)` with `a` as the central atom, its maps will contain pair information relevant to `[a-b, a-c, a-d, b-c, b-d, c-d]`. The first 3 involve the central atom.
