### PR TITLE
Predictable element and interaction tuple ordering (part 2)

### DIFF
--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -52,6 +52,11 @@ class TestChemistryConfig:
         ]  # in this order
         assert handler.numbers == [1, 2, 3, 4,]
 
+    def test_remove_duplicates(self):
+        element_list = ['H', 'H', 'He']
+        handler = ChemicalSystem(element_list)
+        assert handler.numbers == [1, 2]
+
     def test_composition_tuple(self):
         element_list = ['Al', 'Cu', 'Zr']
         handler = ChemicalSystem(element_list)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -50,6 +50,7 @@ class TestChemistryConfig:
             ('Be', 'Li', 'Li'), ('Be', 'Li', 'Be'),
             ('Be', 'Be', 'Be')
         ]  # in this order
+        assert handler.numbers == [1, 2, 3, 4,]
 
     def test_composition_tuple(self):
         element_list = ['Al', 'Cu', 'Zr']

--- a/uf3/data/composition.py
+++ b/uf3/data/composition.py
@@ -49,7 +49,8 @@ class ChemicalSystem:
                 e.g. 2 to fit pair potentials.
         """
         self.degree = degree
-        self.element_list = sort_interaction_symbols(element_list, fix_first=False)
+        self.element_list = sort_interaction_symbols(list(set(element_list)),
+                                                     fix_first=False)
         self.numbers = [ase_symbols.symbols2numbers(el).pop()
                         for el in self.element_list]
         self.interactions_map = self.get_interactions_map()

--- a/uf3/data/composition.py
+++ b/uf3/data/composition.py
@@ -49,7 +49,7 @@ class ChemicalSystem:
                 e.g. 2 to fit pair potentials.
         """
         self.degree = degree
-        self.element_list = sort_interaction_symbols(element_list)
+        self.element_list = sort_interaction_symbols(element_list, fix_first=False)
         self.numbers = [ase_symbols.symbols2numbers(el).pop()
                         for el in self.element_list]
         self.interactions_map = self.get_interactions_map()
@@ -187,12 +187,12 @@ def sort_interaction_map(imap: Dict[Tuple[str], Any]) -> Dict[Tuple[str], Any]:
     return {sort_interaction_symbols(k): v for k, v in imap.items()}
 
 
-def sort_interaction_symbols(symbols: Collection[str]) -> Tuple:
+def sort_interaction_symbols(symbols: Collection[str], fix_first=True) -> Tuple:
     """
     Sort interaction tuple by electronegativities.
     For consistency, many-body interactions (i.e. >2) are sorted while fixing
     the first (center) element."""
-    if len(symbols) >= 3:
+    if len(symbols) >= 3 and fix_first:
         center = symbols[0]
         symbols = sort_elements(symbols[1:])
         symbols.insert(0, center)


### PR DESCRIPTION
I have implemented a proper sorting of `element_list`.

Previously, there were attempts to sort `element_list`, but it was not being done as intended because the same sorting function is used as the one used to sort each 3-body interaction tuple, which was keeping the first atom fixed.

For instance, if the user provides the `element_list = ['He', 'Li', 'H', 'Be']`, it was keeping the `He` fixed and sorting the other 3. So the sorted `element_list` would have been `['He', 'H', 'Li', 'Be']`.

To sort the entire `element_list` while making minimal changes, I have introduced an optional keyword argument `fix_first` in `sort_interaction_symbols()`. The default behavior is to keep the first element fixed, as we have before to sort the 3-body interaction tuples (so this change is fully backward-compatible by not specifying this keyword argument). Only when the `element_list` is sorted, `fix_first` is set to `False` to allow full sorting without keeping the 1st element fixed.