### PR TITLE
initial implementation of saving gram and subsequent training

### DIFF
--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -300,12 +300,10 @@ class WeightedLinearModel(BasicLinearModel):
                                   self.col_idx)
         gram_e, ord_e = batched_moore_penrose(x_e, y_e, batch_size=batch_size)
         if x_f is not None:
-            try:
-                energy_weight = 1 / len(y_e) / np.std(y_e)
-                force_weight = 1 / len(y_f) / np.std(y_f)
-            except (ZeroDivisionError, FloatingPointError):
-                energy_weight = 1.0
-                force_weight = 1 / len(y_f)
+            energy_weight, force_weight = calc_E_F_weights(len(y_e),
+                                                           len(y_f),
+                                                           np.std(y_e),
+                                                           np.std(y_f))
             x_f, y_f = freeze_columns(x_f,
                                       y_f,
                                       self.mask,
@@ -348,22 +346,23 @@ class WeightedLinearModel(BasicLinearModel):
             gram (np.ndarray): gram matrix (x^T x) for fitting.
             ordinate (np.ndarray): ordinate (x^T y) for fitting.
         """
-        gram = (((weight * energy_weight) ** 2 * gram_e)
-                + (((1 - weight) * force_weight) ** 2 * gram_f))
-        ordinate = (((weight * energy_weight) ** 2 * ord_e)
-                    + (((1 - weight) * force_weight) ** 2 * ord_f))
+        gram = ((weight * energy_weight**2 * gram_e)
+                + ((1 - weight) * force_weight**2 * gram_f))
+        ordinate = ((weight * energy_weight**2 * ord_e)
+                    + ((1 - weight) * force_weight**2 * ord_f))
         return gram, ordinate
 
     def fit_from_file(self,
-                      filename: str,
-                      subset: Collection,
-                      weight: float = 0.5,
-                      batch_size=2500,
-                      sample_weights: Dict = None,
-                      energy_key="energy",
-                      progress: str = "bar",
-                      npz_file: str = None,
-                      overwrite: bool = False):
+                    filename: str,
+                    subset: Collection,
+                    weight: float = 0.5,
+                    batch_size=2500,
+                    sample_weights: Dict = None,
+                    energy_key="energy",
+                    progress: str = "bar",
+                    drop_columns: List[str] = None,
+                    npz_file: str = None,
+                    overwrite: bool = False):
         """
         Accumulate inputs and outputs from batched parsing of HDF5 file
         and compute direct solution via LU decomposition.
@@ -378,6 +377,12 @@ class WeightedLinearModel(BasicLinearModel):
             sample_weights (dict):
             energy_key (str): column name for energies, default "energy".
             progress (str): style for progress indicators.
+            drop_columns (list): list of columns to drop. Used when modifying
+                the cutoffs of the feature vectors from HDF5 file. No internal
+                checks are performed to see if dropping provided columns produce
+                features of the intended cutoffs. Use with Caution.
+                npz_file (str): path to npz file for saving gram and ordinate.
+            overwrite (bool): whether to overwrite npz file if it exists.
         """
         _, n_entries_h5, _, _ = io.analyze_hdf_tables(filename)
         if not os.path.isfile(filename):
@@ -389,7 +394,8 @@ class WeightedLinearModel(BasicLinearModel):
                                                             batch_size=batch_size,
                                                             sample_weights=sample_weights,
                                                             energy_key=energy_key,
-                                                            progress=progress)
+                                                            progress=progress,
+                                                            drop_columns=drop_columns)
         else:
             if os.path.isfile(npz_file):
                 gram_ordinate = np.load(npz_file)
@@ -404,7 +410,8 @@ class WeightedLinearModel(BasicLinearModel):
                                                                         batch_size=batch_size,
                                                                         sample_weights=sample_weights,
                                                                         energy_key=energy_key,
-                                                                        progress=progress)
+                                                                        progress=progress,
+                                                                        drop_columns=drop_columns)
                         self.save_gram_ordinate(npz_file, gram, ordinate, n_entries)
                     else:
                         raise ValueError("Number of entries in HDF5 file and npz file are not the same.")
@@ -415,7 +422,8 @@ class WeightedLinearModel(BasicLinearModel):
                                                                 batch_size=batch_size,
                                                                 sample_weights=sample_weights,
                                                                 energy_key=energy_key,
-                                                                progress=progress)
+                                                                progress=progress,
+                                                                drop_columns=drop_columns)
                 self.save_gram_ordinate(npz_file, gram, ordinate, n_entries)
         self.fit_with_gram(gram, ordinate)
 
@@ -426,7 +434,8 @@ class WeightedLinearModel(BasicLinearModel):
                                 batch_size=2500,
                                 sample_weights: Dict = None,
                                 energy_key="energy",
-                                progress: str = "bar"):
+                                progress: str = "bar",
+                                drop_columns: List[str] = None):
 
         """
         Generate gram and ordinate arrays.
@@ -434,11 +443,17 @@ class WeightedLinearModel(BasicLinearModel):
         Args:
             filename (str): path to HDF5 file.
             subset (list): list of keys for training.
+            weight (float): parameter balancing contribution from energies
+                vs. forces. Higher values favor energies; defaults to 0.5.
             batch_size (int): batch size, in rows, for matrix multiplication
                 operations in constructing gram matrices.
             sample_weights (dict):
             energy_key (str): column name for energies, default "energy".
             progress (str): style for progress indicators.
+            drop_columns (list): list of columns to drop. Used when modifying
+                the cutoffs of the feature vectors from HDF5 file. No internal
+                checks are performed to see if dropping provided columns produce
+                features of the intended cutoffs. Use with Caution.
         """
         if not os.path.isfile(filename):
             raise FileNotFoundError(filename)
@@ -454,6 +469,10 @@ class WeightedLinearModel(BasicLinearModel):
             keys = df.index.unique(level=0).intersection(subset)
             if len(keys) == 0:
                 continue
+
+            if drop_columns != None:
+                df.drop(columns=drop_columns,inplace=True)
+
             intermediates = self.gram_from_df(df,
                                               keys,
                                               e_variance=e_variance,
@@ -509,7 +528,6 @@ class WeightedLinearModel(BasicLinearModel):
         ordinate = gram_ordinate["ordinate"]
         self.fit_with_gram(gram, ordinate)
 
-        
     def initialize_gram_ordinate(self):
         """Initialize empty matrices for gram matrices and ordinates."""
         n_columns = self.n_feats - len(self.col_idx)
@@ -573,7 +591,8 @@ class WeightedLinearModel(BasicLinearModel):
                         filename: str,
                         keys: List[str] = None,
                         table_names: List[str] = None,
-                        score: bool = True):
+                        score: bool = True,
+                        drop_columns: List[str] = None):
         """
         Extract inputs and outputs from HDF5 file and predict energies/forces.
 
@@ -590,13 +609,18 @@ class WeightedLinearModel(BasicLinearModel):
             p_f (np.ndarray): prediction values for forces.
             rmse_e (np.ndarray): RMSE across energy predictions.
             rmse_e (np.ndarray): RMSE across force predictions.
+            drop_columns (list): list of columns to drop. Used when modifying
+                the cutoffs of the feature vectors from HDF5 file. No internal
+                checks are performed to see if dropping provided columns produce
+                features of the intended cutoffs. Use with Caution.
         """
         n_elements = len(self.bspline_config.element_list)
         y_e, p_e, y_f, p_f = batched_prediction(self,
                                                 filename,
                                                 table_names=table_names,
                                                 subset_keys=keys,
-                                                n_elements=n_elements)
+                                                n_elements=n_elements,
+                                                drop_columns=drop_columns)
         if score:
             rmse_e = rmse_metric(y_e, p_e)
             rmse_f = rmse_metric(y_f, p_f)
@@ -765,9 +789,6 @@ def dataframe_to_tuples(df_features,
         y (np.ndarray): target vector.
         w (np.ndarray): weight vector for machine learning.
     """
-    if len(df_features) <= 1:
-        raise ValueError(
-            "Not enough samples ({} provided)".format(len(df_features)))
     names = df_features.index.get_level_values(0)
     y_index = df_features.index.get_level_values(-1)
     energy_mask = (y_index == energy_key)
@@ -945,7 +966,7 @@ def freeze_columns(x: np.ndarray,
 def freeze_regularizer(regularizer: np.ndarray,
                        mask: np.ndarray) -> np.ndarray:
     """Apply freezing mask to regularizer, eliminating masked columns."""
-    regularizer = regularizer[mask, :][:, mask]
+    regularizer = regularizer[:, mask]
     return regularizer
 
 
@@ -1050,6 +1071,7 @@ def batched_prediction(model: WeightedLinearModel,
                        filename: str,
                        table_names: Collection = None,
                        subset_keys: Collection = None,
+                       drop_columns: List[str] = None,
                        **kwargs):
     """
     Convenience function for optimization workflow. Read inputs/outputs
@@ -1060,6 +1082,10 @@ def batched_prediction(model: WeightedLinearModel,
         model (WeightedLinearModel): fitted model.
         table_names (list): list of table names to query from HDF5 file.
         subset_keys (list): list of keys to query from DataFrame.
+        drop_columns (list): list of columns to drop. Used when modifying
+            the cutoffs of the feature vectors from HDF5 file. No internal
+            checks are performed to see if dropping provided columns produce
+            features of the intended cutoffs. Use with Caution.
 
     Returns:
         y_e (np.ndarray): target values for energies.
@@ -1075,6 +1101,9 @@ def batched_prediction(model: WeightedLinearModel,
     y_f = []
     p_f = []
     for df in df_batches:
+        if drop_columns != None:
+            df.drop(columns=drop_columns,inplace=True)
+
         predictions = subset_prediction(df,
                                         model,
                                         subset_keys=subset_keys,
@@ -1218,3 +1247,28 @@ def find_pair_potential_well(coefficients, rounding_factor):
             # no actual well
             well_idx = peak_idx + 1
     return well_idx
+
+
+def calc_E_F_weights(n_e, n_f, std_e, std_f):
+    """
+    Calculates weights applied to energy and force components of the
+    least-squares problem (excluding kappa, which is applied in
+    self.combine_weighted_gram()).
+
+    Args:
+        n_e (int): number of energy samples.
+        n_f (int): number of force samples.
+        e_stddev (float): standard deviation of energy samples.
+        f_stddev (float): standard deviation of force samples.
+
+    Returns:
+        energy_weight (float): weight applied to energy components.
+        force_weight (float): weight applied to force components.
+    """
+    if std_e == 0:  # single point or really bad dataset
+        energy_weight = 1.0
+        force_weight = 1 / np.sqrt(n_f)
+    else:
+        energy_weight = 1 / np.sqrt(n_e) / std_e
+        force_weight = 1 / np.sqrt(n_f) / std_f
+    return energy_weight, force_weight

--- a/uf3/regression/least_squares.py
+++ b/uf3/regression/least_squares.py
@@ -489,8 +489,10 @@ class WeightedLinearModel(BasicLinearModel):
             gram_f += g_f
             ord_e += o_e
             ord_f += o_f
-        energy_weight = 1 / e_variance.n / e_variance.std
-        force_weight = 1 / f_variance.n / f_variance.std
+        energy_weight, force_weight = calc_E_F_weights(e_variance.n,
+                                                       f_variance.n,
+                                                       e_variance.std,
+                                                       f_variance.std)
         _, n_entries, _, _ = io.analyze_hdf_tables(filename)
 
             


### PR DESCRIPTION
Hi,
This pull request is in regards to refactoring existing UF3 model training code into smaller functions. More specifically, gram and ordinate generation operations.

**Background:**
During model training the gram and ordinate matrices are generated prior to performing linear regression operations. In the current code, gram and ordinate matrices are generated each time a model is trained. However, repeatedly computing these matrices during a hyperparameter grid search adds a non-trivial computational expense to model training.
**Motivation:** 
The purpose of this pull request is to significantly reduce the computational bottleneck associated with gram and ordinate matrices generation during model hyperparameter optimization. To accomplish this, existing UF3 code has been refactored into smaller functions, such that the gram and ordinate matrices are generated once and then saved to a .npz file. Subsequent model training involves reading in saved .npz files, hence eliminating the need to repeatedly compute these matrices

**Code changes**
Change 1
Addition of '_generate_gram_ordinate_' function, which generates the gram and ordinate matrices.

Change 2: 
Addition of '_save_gram_ordinate_' function, which saves the gram and ordinate matrices.

Change 3: 
Addition of '_fit_from_gram_' function, which fits a model from saved gram and ordinate matrices.

Change 4: 
Modification to '_fit_from_file_' function. Added in functionality to save gram and ordinate matrices, as well as read in previously generated gram and ordinate matrices.


@monk-04 , please review per your request.