### PR TITLE
Update generate_uf3_lammps_pots.py to create a unified potential file as expected by LAMMPS

### DIFF
--- a/lammps_plugin/scripts/generate_uf3_lammps_pots.py
+++ b/lammps_plugin/scripts/generate_uf3_lammps_pots.py
@@ -17,7 +17,7 @@ model = least_squares.WeightedLinearModel.from_json(sys.argv[1])
 
 #struct_elements = set(struct.symbol_set)
 model_elements = set(model.bspline_config.chemical_system.element_list)
-pot_dir = sys.argv[2]
+pot_file = sys.argv[2]
 
 def create_element_map_for_lammps(uf3_chem_sys):
     """Returns dict
@@ -43,115 +43,60 @@ def create_element_map_for_lammps(uf3_chem_sys):
                 else:
                     pass
     return lemap
-"""
-def write_lammps_ip_struct(struct_obj,element_map):
-    """#Returns str
 
-    #Converts a POSCAR to lammps structure format and writes 'lammps.struct' file
-    #Takes pymatgen structure object as the input
-"""
-    struct_dict = struct_obj.as_dict()
-
-    w_filename = 'lammps.struct'
-
-    lx = struct_obj.lattice.a
-    xy = struct_obj.lattice.b * np.cos(struct_obj.lattice.angles[2]*np.pi/180)
-    xz = struct_obj.lattice.c * np.cos(struct_obj.lattice.angles[1]*np.pi/180)
-
-    ly = np.sqrt(np.square(struct_obj.lattice.b) - np.square(xy))
-
-    yz = ((struct_obj.lattice.b*struct_obj.lattice.c*
-           np.cos(struct_obj.lattice.angles[0]*np.pi/180))-(xy*xz))/(ly)
-
-    lz = np.sqrt(np.square(struct_obj.lattice.c)-np.square(xz)-np.square(yz))
-
-    new_H = np.array([[lx,0,0],
-         [xy,ly,0],
-          [xz,yz,lz]])
-
-    fp = open(w_filename,'w')
-    fp.write("# Converted by ACH the great\n\n")
-    fp.write("%i atoms\n"%struct.num_sites)
-    fp.write("%i atom types\n\n"%len(struct.symbol_set))
-
-    fp.write("0.000000%.6f   xlo xhi\n"%lx)
-    fp.write("0.000000%.6f   ylo yhi\n"%ly)
-    fp.write("0.000000%.6f   zlo zhi\n\n"%lz)
-    fp.write("  %.6f%.6f%.6f   xy xz yz\n\n"%(xy,xz,yz))
-
-    fp.write("Masses\n\n")
-
-    for key in element_map:
-        at_mass = Element(key)
-        fp.write("  %i %.5f\n"%(element_map[key],at_mass.atomic_mass))
-        fp.write("\n")
-
-        fp.write("Atoms\n\n")
-    for i in range(0,struct.num_sites):
-        key = struct_dict['sites'][i]['species'][0]['element']
-        temp_cord = np.matmul(struct_dict['sites'][i]['abc'],new_H)
-        fp.write("   %i  %i %.6f %.6f %.6f\n"%(i+1,element_map[key],temp_cord[0],temp_cord[1],temp_cord[2]))
-    fp.close()
-    return w_filename
-"""
-def write_uf3_lammps_pot_files(chemical_sys,model,pot_dir):
+def write_uf3_lammps_pot_file(chemical_sys, model, pot_file, units='metal') -> None:
     """Returns list
 
     Creates and writes UF3 lammps potential files. Takes UF3 composition object,
     UF3 model and name of potential directory as input. Will overwrite the files
     if files with the same exists
     """
-    overwrite = True
-    if not os.path.exists(pot_dir):
-        os.mkdir(pot_dir)
-    files = {}
+    result = ""
 
     for interaction in chemical_sys.interactions_map[2]:
-        key = '_'.join(interaction)
-        files[key] = "#UF3 POT\n"
+        result += "#UF3 POT UNITS: %s \n" % units
         if model.bspline_config.knot_strategy == 'linear':
-            files[key] += "2B %i %i uk\n"%(model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
+            result += "2B %s %s %i %i uk\n" % (interaction[0], interaction[1], model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
         else:
-            files[key] += "2B %i %i nk\n"%(model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
+            result += "2B %s %s %i %i nk\n" % (interaction[0], interaction[1], model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
 
-        files[key] += str(model.bspline_config.r_max_map[interaction]) + " " + \
+        result += str(model.bspline_config.r_max_map[interaction]) + " " + \
                 str(len(model.bspline_config.knots_map[interaction]))+"\n"
 
-        files[key] += " ".join(['{:.17g}'.format(v) for v in \
+        result += " ".join(['{:.17g}'.format(v) for v in \
                 model.bspline_config.knots_map[interaction]]) + "\n"
 
-        files[key] += str(model.bspline_config.get_interaction_partitions()[0][interaction]) \
+        result += str(model.bspline_config.get_interaction_partitions()[0][interaction]) \
                 + "\n"
 
         start_index = model.bspline_config.get_interaction_partitions()[1][interaction]
         length = model.bspline_config.get_interaction_partitions()[0][interaction]
-        files[key] += " ".join(['{:.17g}'.format(v) for v in \
+        result += " ".join(['{:.17g}'.format(v) for v in \
                 model.coefficients[start_index:start_index + length]]) + "\n"
 
-        files[key] += "#"
+        result += "# \n"
 
     if 3 in model.bspline_config.interactions_map:
         for interaction in model.bspline_config.interactions_map[3]:
-            key = '_'.join(interaction)
-            files[key] = "#UF3 POT\n"
+            result += "#UF3 POT UNITS: %s \n" % units
             if model.bspline_config.knot_strategy == 'linear':
-                files[key] += "3B %i %i uk\n"%(model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
+                result += "3B %s %s %s %i %i uk\n" % (interaction[0], interaction[1], interaction[2], model.bspline_config.leading_trim, model.bspline_config.trailing_trim)
             else:
-                files[key] += "3B %i %i nk\n"%(model.bspline_config.leading_trim,model.bspline_config.trailing_trim)
+                result += "3B %s %s %s %i %i nk\n" % (interaction[0], interaction[1], interaction[2], model.bspline_config.leading_trim, model.bspline_config.trailing_trim)
 
-            files[key] += str(model.bspline_config.r_max_map[interaction][2]) \
+            result += str(model.bspline_config.r_max_map[interaction][2]) \
                     + " " + str(model.bspline_config.r_max_map[interaction][1]) \
                     + " " + str(model.bspline_config.r_max_map[interaction][0]) + " "
 
-            files[key] += str(len(model.bspline_config.knots_map[interaction][2])) \
+            result += str(len(model.bspline_config.knots_map[interaction][2])) \
                     + " " + str(len(model.bspline_config.knots_map[interaction][1])) + " " + str(len(model.bspline_config.knots_map[interaction][0])) + "\n"
-            files[key] += " ".join(['{:.17g}'.format(v) for v in \
+            result += " ".join(['{:.17g}'.format(v) for v in \
                     model.bspline_config.knots_map[interaction][2]]) + "\n"
 
-            files[key] += " ".join(['{:.17g}'.format(v) for v in \
+            result += " ".join(['{:.17g}'.format(v) for v in \
                     model.bspline_config.knots_map[interaction][1]]) + "\n"
 
-            files[key] += " ".join(['{:.17g}'.format(v) for v in \
+            result += " ".join(['{:.17g}'.format(v) for v in \
                     model.bspline_config.knots_map[interaction][0]]) + "\n"
 
             solutions = least_squares.arrange_coefficients(model.coefficients, \
@@ -161,23 +106,19 @@ def write_uf3_lammps_pot_files(chemical_sys,model,pot_dir):
                     solutions[(interaction[0], interaction[1],interaction[2])], \
                     (interaction[0], interaction[1],interaction[2]))
 
-            files[key] += str(decompressed.shape[0]) + " " \
+            result += str(decompressed.shape[0]) + " " \
                     + str(decompressed.shape[1]) + " " \
                     + str(decompressed.shape[2]) + "\n"
 
             for i in range(decompressed.shape[0]):
                 for j in range(decompressed.shape[1]):
-                    files[key] += ' '.join(map(str, decompressed[i,j]))
-                    files[key] += "\n"
+                    result += ' '.join(map(str, decompressed[i,j]))
+                    result += "\n"
                     
-            files[key] += "#"
+            result += "# \n"
 
-    for k, v in files.items():
-        if not overwrite and os.path.exists(pot_dir + k):
-            continue
-        with open(pot_dir +"/"+ k, "w") as f:
-            f.write(v)
-    return files.keys()
+    with open(pot_file, 'w') as f:
+        f.write(result)
 
 """
 if len(model_elements.intersection(struct_elements))==len(struct_elements):
@@ -208,9 +149,22 @@ else:
 
 chemical_sys = model.bspline_config.chemical_system
 
-pot_files = write_uf3_lammps_pot_files(chemical_sys=chemical_sys,model=model,pot_dir=pot_dir)
-pot_files = list(pot_files)
-lines = "pair_style uf3 %i %i"%(model.bspline_config.degree,len(chemical_sys.element_list))
+write_uf3_lammps_pot_file(chemical_sys=chemical_sys, model=model, pot_file=pot_file)
+# pot_files = list(pot_files)
+lines = "pair_style uf3 %i \n" % model.bspline_config.degree
+
+# TODO: add the pair_coeff line with the correct ordering of atom types
+# lines += "pair_coeff * * %s" % pot_file
+
+# element_map = create_element_map_for_lammps(chemical_sys)
+# keys = []
+# values = []
+# for k, v in element_map.items():
+#     keys.append(k)
+#     values.append(v)
+# idx = np.argsort(values)
+# keys = [keys[i] for i in idx]
+# lines += " " + ' '.join(keys) + '\n'
 
 """
 for interaction in chemical_sys.interactions_map[2]:
@@ -220,6 +174,7 @@ if 3 in model.bspline_config.interactions_map:
     for interaction in model.bspline_config.interactions_map[3]:
         lines += " %s/%s"%(pot_dir,'_'.join(interaction))
 """
+
 print("\n\n***Add the following line to the lammps input script followed by the 'pair_coeff' line/s***\n\n")
 print(lines)
 print("\n\n")


### PR DESCRIPTION
As the title says. The way the current script outputs LAMMPS-readable potentials is not compatible with the UF3 package in LAMMPS (version 27Jun2024). This will output a unified file consistent with the [LAMMPS documentation for UF3](https://docs.lammps.org/pair_uf3.html). It will also output the `pair_coeff` line with a guess for what the ordering of the elements should be, though there is no standard as far as I'm aware, so the script will also print out a short warning to get users to check if this order is appropriate.  Currently it's just alphabetical order, which I believe is what ASE uses. 