### PR TITLE
Temporarily pin Numpy to <=1.26.4, and replace Python 3.8 support with Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,12 @@ jobs:
         python --version
         pip install -U pip pytest
         pip install setuptools_scm
-        pip install numpy==1.24.4
+        # numpy 1.24.4 for python3.8 and 1.26.4 for python3.9 and higher
+        if [[ "${{ matrix.python-version }}" == "3.8" ]]; then
+          pip install numpy==1.24.4
+        else
+          pip install numpy==1.26.4
+        fi
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         python --version
         pip install -U pip pytest
         pip install setuptools_scm
-        pip install numpy==1.26.4
+        pip install numpy==1.24.4
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
         python --version
         pip install -U pip pytest
         pip install setuptools_scm
+        pip install numpy==1.26.4
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
@@ -39,12 +39,8 @@ jobs:
         python --version
         pip install -U pip pytest
         pip install setuptools_scm
-        # numpy 1.24.4 for python3.8 and 1.26.4 for python3.9 and higher
-        if [[ "${{ matrix.python-version }}" == "3.8" ]]; then
-          pip install numpy==1.24.4
-        else
-          pip install numpy==1.26.4
-        fi
+        # temporary pinning of Numpy version until packages work with Numpy v2
+        pip install numpy==1.26.4
         pip install .
     - name: Test with pytest
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ase
 matplotlib
 ndsplines
 numba
-numpy
+numpy<=1.26.4
 pandas
 plotly
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,16 @@ if __name__ == "__main__":
         packages=setuptools.find_packages(exclude=["tests"]),
         install_requires=install_requires,
         extras_require=extras_require,
-        classifiers=["Programming Language :: Python :: 3.7",
-                     'Development Status :: 3 - Alpha',
-                     'Intended Audience :: Science/Research',
-                     'Operating System :: OS Independent',
-                     'Topic :: Scientific/Engineering'],
+        classifiers=[
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            'Development Status :: 3 - Alpha',
+            'Intended Audience :: Science/Research',
+            'Operating System :: OS Independent',
+            'Topic :: Scientific/Engineering'
+        ],
+        python_requires='>=3.9, <3.13',
         tests_require=test_requires,
     )


### PR DESCRIPTION
The new release of Numpy version 2.0.0 has been causing some import errors (see https://github.com/uf3/uf3/pull/117#issuecomment-2183486400). As a temporary fix, the Numpy version was pinned down to 1.26.4 (the latest version 1) in the UF3 testsuite and <=1.26.4 for the pip installation.

Furthermore, as Python 3.8 is reaching its end of life in just several months (October 2024), I have removed it from the testsuite, and I have replaced it with Python 3.12, which was released in October 2023.