### PR TITLE
Update versions of Github actions in the unit test workflow file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: local-fix
       run: |
         # Hack to get setup-python to work on act
@@ -29,7 +29,7 @@ jobs:
           echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
         fi
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
I was notified by Github of this:

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

And this seems to be a solution:

https://stackoverflow.com/questions/76056803/update-your-actions-to-run-on-node-16-instead-of-node-12-on-github

So I have updated UF3's `.github/workflows/tests.yml` file accordingly.