### PR TITLE
Update generate_uf3_lammps_pots.py

### DIFF
--- a/lammps_plugin/scripts/generate_uf3_lammps_pots.py
+++ b/lammps_plugin/scripts/generate_uf3_lammps_pots.py
@@ -1,5 +1,4 @@
 from uf3.regression import least_squares
-from pymatgen.core import Element
 from uf3.data import composition
 import numpy as np
 import os, sys, argparse

--- a/lammps_plugin/scripts/generate_uf3_lammps_pots.py
+++ b/lammps_plugin/scripts/generate_uf3_lammps_pots.py
@@ -1,5 +1,4 @@
 from uf3.regression import least_squares
-from pymatgen.core.structure import Structure
 from pymatgen.core import Element
 from uf3.data import composition
 import numpy as np


### PR DESCRIPTION
Deleted pymatgen Structure import. It was needed in the older version but not in the current one.